### PR TITLE
[BMC] Add new Redfish methods for manual session management

### DIFF
--- a/tests/mock_data/mock_bmc_empty_response
+++ b/tests/mock_data/mock_bmc_empty_response
@@ -1,2 +1,10 @@
 
+{
+  "@odata.id": "/redfish/v1/AccountService",
+  "@odata.type": "#AccountService.v1_15_0.AccountService",
+  "Description": "Account Service",
+  "Id": "AccountService",
+  "Name": "Account Service",
+  "ServiceEnabled": true
+}
 HTTP Status Code: 200

--- a/tests/mock_data/mock_bmc_get_account_service_response
+++ b/tests/mock_data/mock_bmc_get_account_service_response
@@ -1,0 +1,55 @@
+{
+  "@odata.id": "/redfish/v1/AccountService",
+  "@odata.type": "#AccountService.v1_15_0.AccountService",
+  "AccountLockoutDuration": 20,
+  "AccountLockoutThreshold": 10,
+  "Accounts": {
+    "@odata.id": "/redfish/v1/AccountService/Accounts"
+  },
+  "Description": "Account Service",
+  "HTTPBasicAuth": "Enabled",
+  "HTTPBasicAuth@AllowableValues": [
+    "Enabled",
+    "Disabled"
+  ],
+  "Id": "AccountService",
+  "LDAP": {
+    "Certificates": {
+      "@odata.id": "/redfish/v1/AccountService/LDAP/Certificates"
+    }
+  },
+  "MaxPasswordLength": 64,
+  "MinPasswordLength": 13,
+  "MultiFactorAuth": {
+    "ClientCertificate": {
+      "CertificateMappingAttribute": "CommonName",
+      "Certificates": {
+        "@odata.id": "/redfish/v1/AccountService/MultiFactorAuth/ClientCertificate/Certificates",
+        "@odata.type": "#CertificateCollection.CertificateCollection",
+        "Members": [],
+        "Members@odata.count": 0
+      },
+      "Enabled": true,
+      "RespondToUnauthenticatedClients": true
+    }
+  },
+  "Name": "Account Service",
+  "Oem": {
+    "OpenBMC": {
+      "@odata.id": "/redfish/v1/AccountService#/Oem/OpenBMC",
+      "@odata.type": "#OpenBMCAccountService.v1_0_0.AccountService",
+      "AuthMethods": {
+        "BasicAuth": true,
+        "Cookie": true,
+        "SessionToken": true,
+        "TLS": true,
+        "XToken": true
+      }
+    }
+  },
+  "Roles": {
+    "@odata.id": "/redfish/v1/AccountService/Roles"
+  },
+  "ServiceEnabled": true
+}
+HTTP Status Code: 200

--- a/tests/mock_data/mock_bmc_set_min_password_length_failure_response
+++ b/tests/mock_data/mock_bmc_set_min_password_length_failure_response
@@ -1,0 +1,30 @@
+{
+  "@Message.ExtendedInfo": [
+    {
+      "@odata.type": "#Message.v1_1_1.Message",
+      "Message": "The request completed successfully.",
+      "MessageArgs": [],
+      "MessageId": "Base.1.18.1.Success",
+      "MessageSeverity": "OK",
+      "Resolution": "None."
+    }
+  ],
+  "error": {
+    "@Message.ExtendedInfo": [
+      {
+        "@odata.type": "#Message.v1_1_1.Message",
+        "Message": "The property 'MinPasswordLength' with the requested value of '5' could not be written because the value does not meet the constraints of the implementation.",
+        "MessageArgs": [
+          "MinPasswordLength",
+          "5"
+        ],
+        "MessageId": "Base.1.18.1.PropertyValueIncorrect",
+        "MessageSeverity": "Warning",
+        "Resolution": "None."
+      }
+    ],
+    "code": "Base.1.18.1.PropertyValueIncorrect",
+    "message": "The property 'MinPasswordLength' with the requested value of '5' could not be written because the value does not meet the constraints of the implementation."
+  }
+}
+HTTP Status Code: 200

--- a/tests/mock_data/mock_bmc_set_min_password_length_success_response
+++ b/tests/mock_data/mock_bmc_set_min_password_length_success_response
@@ -1,0 +1,13 @@
+{
+  "@Message.ExtendedInfo": [
+    {
+      "@odata.type": "#Message.v1_1_1.Message",
+      "Message": "The request completed successfully.",
+      "MessageArgs": [],
+      "MessageId": "Base.1.18.1.Success",
+      "MessageSeverity": "OK",
+      "Resolution": "None."
+    }
+  ]
+}
+HTTP Status Code: 200

--- a/tests/mock_data/mock_session_service_sessions_response
+++ b/tests/mock_data/mock_session_service_sessions_response
@@ -1,0 +1,13 @@
+{
+  "@odata.id": "/redfish/v1/SessionService/Sessions",
+  "@odata.type": "#SessionCollection.SessionCollection",
+  "Description": "Session Collection",
+  "Members": [
+    {
+      "@odata.id": "/redfish/v1/SessionService/Sessions/abc123xyz"
+    }
+  ],
+  "Members@odata.count": 1,
+  "Name": "Session Collection"
+}
+HTTP Status Code: 200

--- a/tests/redfish_client_test.py
+++ b/tests/redfish_client_test.py
@@ -1315,3 +1315,158 @@ class TestRedfishClient:
         
         assert ret == RedfishClient.ERR_CODE_UNEXPECTED_RESPONSE
         assert "Missing 'message' field" in msg
+
+    @mock.patch('subprocess.Popen')
+    def test_set_min_password_length_success(self, mock_popen):
+        """Test setting minimum password length successfully"""
+        side_effects = []
+        for fname in ['mock_bmc_login_token_response', 
+                      'mock_bmc_set_min_password_length_success_response']:
+            output = (load_redfish_response(fname), b'')
+            mock_process = mock.Mock()
+            mock_process.communicate.return_value = output
+            mock_process.returncode = 0
+            side_effects.append(mock_process)
+
+        mock_popen.side_effect = side_effects
+        rf = RedfishClient(TestRedfishClient.CURL_PATH,
+                           TestRedfishClient.BMC_INTERNAL_IP_ADDR,
+                           self.user_callback,
+                           self.password_callback)
+
+        ret = rf.login()
+        assert ret == RedfishClient.ERR_CODE_OK
+        
+        ret, msg = rf.redfish_api_set_min_password_length(10)
+        assert ret == RedfishClient.ERR_CODE_OK
+        assert msg == ''
+
+    @mock.patch('subprocess.Popen')
+    def test_set_min_password_length_failure(self, mock_popen):
+        """Test setting minimum password length with failure response"""
+        side_effects = []
+        for fname in ['mock_bmc_login_token_response', 
+                      'mock_bmc_set_min_password_length_failure_response']:
+            output = (load_redfish_response(fname), b'')
+            mock_process = mock.Mock()
+            mock_process.communicate.return_value = output
+            mock_process.returncode = 0
+            side_effects.append(mock_process)
+
+        mock_popen.side_effect = side_effects
+        rf = RedfishClient(TestRedfishClient.CURL_PATH,
+                           TestRedfishClient.BMC_INTERNAL_IP_ADDR,
+                           self.user_callback,
+                           self.password_callback)
+
+        ret = rf.login()
+        assert ret == RedfishClient.ERR_CODE_OK
+        
+        ret, msg = rf.redfish_api_set_min_password_length(5)
+        assert ret == RedfishClient.ERR_CODE_GENERIC_ERROR
+        assert "could not be written" in msg
+
+    @mock.patch('subprocess.Popen')
+    def test_get_min_password_length_success(self, mock_popen):
+        """Test getting minimum password length successfully"""
+        side_effects = []
+        for fname in ['mock_bmc_login_token_response', 
+                      'mock_bmc_get_account_service_response']:
+            output = (load_redfish_response(fname), b'')
+            mock_process = mock.Mock()
+            mock_process.communicate.return_value = output
+            mock_process.returncode = 0
+            side_effects.append(mock_process)
+
+        mock_popen.side_effect = side_effects
+        rf = RedfishClient(TestRedfishClient.CURL_PATH,
+                           TestRedfishClient.BMC_INTERNAL_IP_ADDR,
+                           self.user_callback,
+                           self.password_callback)
+
+        ret = rf.login()
+        assert ret == RedfishClient.ERR_CODE_OK
+        
+        ret, min_length = rf.redfish_api_get_min_password_length()
+        assert ret == RedfishClient.ERR_CODE_OK
+        assert min_length == 13
+
+    @mock.patch('subprocess.Popen')
+    def test_get_min_password_length_empty_response(self, mock_popen):
+        """Test getting minimum password length with empty response"""
+        side_effects = []
+        for fname in ['mock_bmc_login_token_response', 
+                      'mock_bmc_empty_response']:
+            output = (load_redfish_response(fname), b'')
+            mock_process = mock.Mock()
+            mock_process.communicate.return_value = output
+            mock_process.returncode = 0
+            side_effects.append(mock_process)
+
+        mock_popen.side_effect = side_effects
+        rf = RedfishClient(TestRedfishClient.CURL_PATH,
+                           TestRedfishClient.BMC_INTERNAL_IP_ADDR,
+                           self.user_callback,
+                           self.password_callback)
+
+        ret = rf.login()
+        assert ret == RedfishClient.ERR_CODE_OK
+        
+        ret, msg = rf.redfish_api_get_min_password_length()
+        assert ret == RedfishClient.ERR_CODE_UNEXPECTED_RESPONSE
+        assert "MinPasswordLength not found" in msg
+
+    @mock.patch('subprocess.Popen')
+    def test_open_session_success(self, mock_popen):
+        """Test successful session opening"""
+        output = (load_redfish_response('mock_bmc_login_token_response'), b'')
+        mock_process = mock.Mock()
+        mock_process.communicate.return_value = output
+        mock_process.returncode = 0
+        
+        mock_popen.return_value = mock_process
+        rf = RedfishClient(TestRedfishClient.CURL_PATH,
+                           TestRedfishClient.BMC_INTERNAL_IP_ADDR,
+                           self.user_callback,
+                           self.password_callback)
+        
+        ret, (msg, credentials) = rf.open_session()
+        assert ret == RedfishClient.ERR_CODE_OK
+        assert msg == 'Login successful'
+        assert credentials is not None
+        assert credentials[0] == 'abc123xyz'
+        assert credentials[1] == 'TVZI0pf8VCGbYAhw9cIF'
+
+    @mock.patch('subprocess.Popen')
+    def test_close_session_success(self, mock_popen):
+        """Test successful session closure"""
+        side_effects = []
+        
+        output = (load_redfish_response('mock_bmc_login_token_response'), b'')
+        mock_process = mock.Mock()
+        mock_process.communicate.return_value = output
+        mock_process.returncode = 0
+        side_effects.append(mock_process)
+        
+        output = (load_redfish_response('mock_session_service_sessions_response'), b'')
+        mock_process = mock.Mock()
+        mock_process.communicate.return_value = output
+        mock_process.returncode = 0
+        side_effects.append(mock_process)
+        
+        output = (load_redfish_response('mock_bmc_logout_response'), b'')
+        mock_process = mock.Mock()
+        mock_process.communicate.return_value = output
+        mock_process.returncode = 0
+        side_effects.append(mock_process)
+        
+        mock_popen.side_effect = side_effects
+        rf = RedfishClient(TestRedfishClient.CURL_PATH,
+                           TestRedfishClient.BMC_INTERNAL_IP_ADDR,
+                           self.user_callback,
+                           self.password_callback)
+        
+        rf.login()
+        ret, msg = rf.close_session('abc123xyz')
+        assert ret == RedfishClient.ERR_CODE_OK
+        assert msg == 'Session closed successfully'


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->
Added new BMC and Redfish methods for the CLIs of:
- Reset the BMC root password
- Manually open a BMC session to get a token
- Manually close a BMC session

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->
If the user forgets the BMC root password, we will provide the SONiC CLI to reset it to the default.
If the user wants to send direct Redfish commands (without SONiC CLIs),
we will provide a SONiC CLI for getting a BMC Auth session token.

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->
config bmc reset-root-password
config bmc open-session
config bmc close-session --session-id <session-id>

#### Additional Information (Optional)

