### PR TITLE
[BMC] Align get_presence for the new infra

### DIFF
--- a/sonic_platform_base/bmc_base.py
+++ b/sonic_platform_base/bmc_base.py
@@ -268,8 +268,7 @@ class BMCBase(device_base.DeviceBase):
             A boolean indicating whether the BMC device is present
         """
         from sonic_py_common import device_info
-        bmc_data = device_info.get_bmc_data()
-        if bmc_data and bmc_data.get('bmc_addr'):
+        if device_info.is_switch_host() and device_info.get_bmc_data():
             return True
         return False
 

--- a/tests/bmc_base_test.py
+++ b/tests/bmc_base_test.py
@@ -53,17 +53,28 @@ class TestBMCBase:
         bmc = BMCBase('169.254.0.1')
         assert bmc.get_name() == BMCBase.BMC_NAME
 
-    def test_get_presence_true(self):
-        """Test get_presence returns True when BMC data is present"""
-        with mock.patch('sonic_py_common.device_info.get_bmc_data', create=True, return_value={'bmc_addr': '169.254.0.1'}):
-            bmc = BMCBase('169.254.0.1')
-            assert bmc.get_presence() == True
+    @mock.patch('sonic_py_common.device_info.is_switch_host', create=True, return_value=True)
+    @mock.patch('sonic_py_common.device_info.get_bmc_data', create=True,
+                return_value={'bmc_addr': '169.254.0.1'})
+    def test_get_presence_true(self, mock_get_bmc_data, mock_is_switch_host):
+        """Test get_presence returns True on Switch-Host when bmc.json data exists"""
+        bmc = BMCBase('169.254.0.1')
+        assert bmc.get_presence() is True
 
-    def test_get_presence_false(self):
-        """Test get_presence returns False when BMC data is not present"""
-        with mock.patch('sonic_py_common.device_info.get_bmc_data', create=True, return_value=None):
-            bmc = BMCBase('169.254.0.1')
-            assert bmc.get_presence() == False
+    @mock.patch('sonic_py_common.device_info.is_switch_host', create=True, return_value=True)
+    @mock.patch('sonic_py_common.device_info.get_bmc_data', create=True, return_value=None)
+    def test_get_presence_false_no_bmc_data(self, mock_get_bmc_data, mock_is_switch_host):
+        """Test get_presence returns False when /etc/sonic/bmc.json is unavailable"""
+        bmc = BMCBase('169.254.0.1')
+        assert bmc.get_presence() is False
+
+    @mock.patch('sonic_py_common.device_info.is_switch_host', create=True, return_value=False)
+    @mock.patch('sonic_py_common.device_info.get_bmc_data', create=True,
+                return_value={'bmc_addr': '169.254.0.1'})
+    def test_get_presence_false_not_switch_host(self, mock_get_bmc_data, mock_is_switch_host):
+        """Test get_presence returns False on Switch-BMC even if bmc.json data exists"""
+        bmc = BMCBase('169.254.0.1')
+        assert bmc.get_presence() is False
 
     def test_is_replaceable(self):
         """Test is_replaceable returns False"""

--- a/tests/bmc_base_test.py
+++ b/tests/bmc_base_test.py
@@ -56,14 +56,14 @@ class TestBMCBase:
     @mock.patch('sonic_py_common.device_info.is_switch_host', create=True, return_value=True)
     @mock.patch('sonic_py_common.device_info.get_bmc_data', create=True,
                 return_value={'bmc_addr': '169.254.0.1'})
-    def test_get_presence_true(self, mock_get_bmc_data, mock_is_switch_host):
+    def test_get_presence_true(self, _mock_get_bmc_data, _mock_is_switch_host):
         """Test get_presence returns True on Switch-Host when bmc.json data exists"""
         bmc = BMCBase('169.254.0.1')
         assert bmc.get_presence() is True
 
     @mock.patch('sonic_py_common.device_info.is_switch_host', create=True, return_value=True)
     @mock.patch('sonic_py_common.device_info.get_bmc_data', create=True, return_value=None)
-    def test_get_presence_false_no_bmc_data(self, mock_get_bmc_data, mock_is_switch_host):
+    def test_get_presence_false_no_bmc_data(self, _mock_get_bmc_data, _mock_is_switch_host):
         """Test get_presence returns False when /etc/sonic/bmc.json is unavailable"""
         bmc = BMCBase('169.254.0.1')
         assert bmc.get_presence() is False
@@ -71,7 +71,7 @@ class TestBMCBase:
     @mock.patch('sonic_py_common.device_info.is_switch_host', create=True, return_value=False)
     @mock.patch('sonic_py_common.device_info.get_bmc_data', create=True,
                 return_value={'bmc_addr': '169.254.0.1'})
-    def test_get_presence_false_not_switch_host(self, mock_get_bmc_data, mock_is_switch_host):
+    def test_get_presence_false_not_switch_host(self, _mock_get_bmc_data, _mock_is_switch_host):
         """Test get_presence returns False on Switch-BMC even if bmc.json data exists"""
         bmc = BMCBase('169.254.0.1')
         assert bmc.get_presence() is False


### PR DESCRIPTION
#### Why I did it
`BMCBase.get_presence()` was aligned with the new host/BMC split so BMC presence is reported only for
Switch-Host platforms with runtime BMC data. This avoids treating Switch-BMC side execution as BMC-present
for host-only logic.

##### Work item tracking
- Microsoft ADO **(number only)**: N/A

#### How I did it
- Updated `sonic_platform_base/bmc_base.py` to check:
  - `device_info.is_switch_host()`
  - `device_info.get_bmc_data()`
- Removed the older `bmc_addr`-only presence condition.
- Updated `tests/bmc_base_test.py` to match the new behavior:
  - present on Switch-Host with bmc data
  - not present when bmc data is missing
  - not present on non-host even if bmc data exists

#### How to verify it
- Run unit tests:
  - `pytest tests/bmc_base_test.py`
- Validate platform API behavior manually:
  - `bmc.get_presence()` returns `True` only on Switch-Host with valid `/etc/sonic/bmc.json`
  - returns `False` on Switch-BMC side or when BMC data is unavailable

#### Which release branch to backport (provide reason below if selected)
- [ ] 201811
- [ ] 201911
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

#### Tested branch (Please provide the tested image version)
- [ ] <image-version-1>

#### Description for the changelog
[BMC] Align get_presence for the new infra